### PR TITLE
Modified package.json to use shorter repository location syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,7 @@
     "test:system": "jest src/__test__/*.test.ts --runInBand",
     "test:all": "jest src/*/*.test.ts --runInBand"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/IBM/zos-node-accessor"
-  },
+  "repository": "IBM/zos-node-accessor",
   "keywords": [
     "dataset",
     "ftp",


### PR DESCRIPTION
This PR solves the issue #50 

Like mentioned in the npm package.json specification [here](https://docs.npmjs.com/files/package.json): 
`For GitHub, GitHub gist, Bitbucket, or GitLab repositories you can use the same shortcut syntax you use for npm install`

This also resolves a problem when installing via CITGM.